### PR TITLE
manifest: mark arch independent.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>message_runtime</exec_depend>
 
   <export>
+    <architecture_independent />
     <rosindex>
       <tags>
         <tag>messages</tag>


### PR DESCRIPTION
As per subject.

As recommended by [REP-140](https://www.ros.org/reps/rep-0140.html#architecture-independent).
