### PR TITLE
Added center_of_gravity to SetPayload service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(ur_msgs)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)
+find_package(catkin REQUIRED COMPONENTS geometry_msgs message_generation std_msgs)
 
 
 ## Generate messages in the 'msg' folder
@@ -31,6 +31,7 @@ add_service_files(
 ## Generate added messages and services with any dependencies listed here
 generate_messages(
    DEPENDENCIES
+   geometry_msgs
    std_msgs
 )
 
@@ -40,7 +41,7 @@ generate_messages(
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES ur_msgs
-   CATKIN_DEPENDS message_runtime std_msgs
+   CATKIN_DEPENDS geometry_msgs message_runtime std_msgs
 #  DEPENDS system_lib
 )
 

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
+  <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
   <exec_depend>message_runtime</exec_depend>
 

--- a/srv/SetPayload.srv
+++ b/srv/SetPayload.srv
@@ -1,3 +1,4 @@
 float32 payload
+geometry_msgs/Vector3 center_of_gravity
 -----------------------
 bool success


### PR DESCRIPTION
"Newer" version of URScript (>= 1.7) have the CoG as second optional
parameter to the script function setting up the payload.

As we'd like to add this service to the ur_robot_driver I'd like to add this suggestion here. As far as I know, this is being used by both, the ur_driver and the ur_modern_driver, which is why I left the payload field untouched.

I had the feeling that duplicating this message into another message package is not the right way to go.

First of all, I wanted to start the discussion here. Once we figured out the final solution, I'd propose to also include this into kinetic-devel, as the ur_robot_driver is also working with kinetic.

This is https://github.com/ros-industrial/universal_robot/pull/470 reopened on the new `ur_msgs` repository