### PR TITLE
Change "payload" field name to "mass"

### DIFF
--- a/srv/SetPayload.srv
+++ b/srv/SetPayload.srv
@@ -1,4 +1,4 @@
-float32 payload
+float32 mass
 geometry_msgs/Vector3 center_of_gravity
 -----------------------
 bool success


### PR DESCRIPTION
Followup on #2 

Since we extended this service to also contain the cog, IMHO it makes sense to rename the "payload" field to "mass" as it is named inside UR's documentation.