### PR TITLE
Invalid separator in SetPayload srv

### DIFF
--- a/srv/SetPayload.srv
+++ b/srv/SetPayload.srv
@@ -1,4 +1,4 @@
 float32 mass
 geometry_msgs/Vector3 center_of_gravity
------------------------
+---
 bool success


### PR DESCRIPTION
I know this will potentially break a lot of things, so maybe this doesn't need to be merged at this moment, but the current field name and separator will not be able to build in ROS2 or a ROS1-ROS2 bridge.
Changes:
- ~~License and DCO~~
- ~~Change field name to fit ROS2 regex check~~
- fix invalid separator