### PR TITLE
Document pin mapping in SetIO service

### DIFF
--- a/srv/SetIO.srv
+++ b/srv/SetIO.srv
@@ -7,6 +7,9 @@
 #
 #  fun    The function to perform
 #  pin    Numeric ID of the pin to set
+#         Use pin 0-7 for digital / analog outputs
+#         Use pin 8-15 for configurable outputs
+#         Use pin 16, 17 for digital tool output
 #  state  Desired pin state (signal level for analog or STATE_(ON|OFF) for DIO and flags)
 #
 # When configuring tool voltage:

--- a/srv/SetIO.srv
+++ b/srv/SetIO.srv
@@ -17,26 +17,33 @@
 
 # constants
 # pin mapping
-int8 DOUT0 = 0
-int8 DOUT1 = 1
-int8 DOUT2 = 2
-int8 DOUT3 = 3
-int8 DOUT4 = 4
-int8 DOUT5 = 5
-int8 DOUT6 = 6
-int8 DOUT7 = 7
-int8 COUT0 = 8
-int8 COUT1 = 9
-int8 COUT2 = 10
-int8 COUT3 = 11
-int8 COUT4 = 12
-int8 COUT5 = 13
-int8 COUT6 = 14
-int8 COUT7 = 15
-int8 TOOL_OUT0 = 16
-int8 TOOL_OUT1 = 17
-int8 AOUT0 = 0
-int8 AOUT1 = 1
+# analog out
+int8 PIN_AOUT0 = 0
+int8 PIN_AOUT1 = 1
+
+# digital out
+int8 PIN_DOUT0 = 0
+int8 PIN_DOUT1 = 1
+int8 PIN_DOUT2 = 2
+int8 PIN_DOUT3 = 3
+int8 PIN_DOUT4 = 4
+int8 PIN_DOUT5 = 5
+int8 PIN_DOUT6 = 6
+int8 PIN_DOUT7 = 7
+
+# configurable out
+int8 PIN_CONF_OUT0 = 8
+int8 PIN_CONF_OUT1 = 9
+int8 PIN_CONF_OUT2 = 10
+int8 PIN_CONF_OUT3 = 11
+int8 PIN_CONF_OUT4 = 12
+int8 PIN_CONF_OUT5 = 13
+int8 PIN_CONF_OUT6 = 14
+int8 PIN_CONF_OUT7 = 15
+
+# digital tool output
+int8 PIN_TOOL_DOUT0 = 16
+int8 PIN_TOOL_DOUT1 = 17
 
 # valid function values
 #

--- a/srv/SetIO.srv
+++ b/srv/SetIO.srv
@@ -6,10 +6,7 @@
 # When setting DIO or AIO pins to new values:
 #
 #  fun    The function to perform
-#  pin    Numeric ID of the pin to set
-#         Use pin 0-7 for digital / analog outputs
-#         Use pin 8-15 for configurable outputs
-#         Use pin 16, 17 for digital tool output
+#  pin    Numeric ID of the pin to set, see constants definition below
 #  state  Desired pin state (signal level for analog or STATE_(ON|OFF) for DIO and flags)
 #
 # When configuring tool voltage:
@@ -19,6 +16,27 @@
 #  state  Desired tool voltage (use STATE_TOOL_VOLTAGE constants)
 
 # constants
+# pin mapping
+int8 DOUT0 = 0
+int8 DOUT1 = 1
+int8 DOUT2 = 2
+int8 DOUT3 = 3
+int8 DOUT4 = 4
+int8 DOUT5 = 5
+int8 DOUT6 = 6
+int8 DOUT7 = 7
+int8 COUT0 = 8
+int8 COUT1 = 9
+int8 COUT2 = 10
+int8 COUT3 = 11
+int8 COUT4 = 12
+int8 COUT5 = 13
+int8 COUT6 = 14
+int8 COUT7 = 15
+int8 TOOL_OUT0 = 16
+int8 TOOL_OUT1 = 17
+int8 AOUT0 = 0
+int8 AOUT1 = 1
 
 # valid function values
 #


### PR DESCRIPTION
The service has been implemented like this in the [`ur_modern_driver`](https://github.com/ros-industrial/ur_modern_driver/blob/kinetic-devel/src/ur/commander.cpp#L121) and is also like that in the [`ur_robot_driver`](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/blob/master/ur_robot_driver/src/hardware_interface.cpp#L852).

However, as far as I can see, this is not documented anywhere (at least not anywhere I would expect it).