### PR TITLE
ci: bump checkout and cache (ROS 2)

### DIFF
--- a/.github/workflows/ci_ros2_stable.yml
+++ b/.github/workflows/ci_ros2_stable.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Fetch repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: ccache cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CCACHE_DIR }}
           # we always want the ccache cache to be persisted, as we cannot easily


### PR DESCRIPTION
As per subject.

The currently used versions are deprecated and produce a number of warnings (and soon errors).
