### PR TITLE
[ROS 2] Update README and ci

### DIFF
--- a/.github/workflows/ci_ros2_stable.yml
+++ b/.github/workflows/ci_ros2_stable.yml
@@ -12,19 +12,19 @@ on:
 jobs:
   industrial_ci:
     name: ROS ${{ matrix.ros_distro }} (${{ matrix.ros_repo }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
-        ros_distro: [ foxy, galactic ]
-        ros_repo: [ main ]
+        ros_distro: [humble, iron, jazzy, rolling]
+        ros_repo: [main]
 
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
 
     steps:
       - name: Fetch repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: ccache cache
         uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ur_msgs
 
-[![Build Status](http://build.ros.org/job/Mdev__ur_msgs__ubuntu_bionic_amd64/badge/icon)](http://build.ros.org/job/Mdev__ur_msgs__ubuntu_bionic_amd64)
-[![Build Status: Travis CI](https://travis-ci.com/ros-industrial/ur_msgs.svg?branch=melodic-devel)](https://travis-ci.com/ros-industrial/ur_msgs)
-[![Github Issues](https://img.shields.io/github/issues/ros-industrial/ur_msgs.svg)](http://github.com/ros-industrial/ur_msgs/issues)
+[![Build Status](https://build.ros2.org/job/Hbin_uJ64__ur_msgs__ubuntu_jammy_amd64__binary/badge/icon)](https://build.ros2.org/job/Hbin_uJ64__ur_msgs__ubuntu_jammy_amd64__binary/)
+[![CI - ROS2 stable](https://github.com/ros-industrial/ur_msgs/actions/workflows/ci_ros2_stable.yml/badge.svg?branch=humble-devel)](https://github.com/ros-industrial/ur_msgs/actions/workflows/ci_ros2_stable.yml)
+[![GitHub Issues](https://img.shields.io/github/issues/ros-industrial/ur_msgs.svg)](http://github.com/ros-industrial/ur_msgs/issues)
 
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
@@ -10,4 +10,4 @@
 
 Message and service definitions for use with packages supporting and interacting with Universal Robots' robot controllers.
 
-See the ROS wiki for more information: [wiki/ur_msgs](http://wiki.ros.org/ur_msgs).
+See the ROS index for more information: [index.ros.org/p/ur_msgs](https://index.ros.org/p/ur_msgs/github-ros-industrial-ur_msgs/#humble).

--- a/msg/MasterboardDataMsg.msg
+++ b/msg/MasterboardDataMsg.msg
@@ -1,7 +1,7 @@
 # This data structure contains the MasterboardData structure
 # used by the Universal Robots controller
 #
-# MasterboardData is part of the data structure being send on the 
+# MasterboardData is part of the data structure being send on the
 # secondary client communications interface
 # 
 # This data structure is send at 10 Hz on TCP port 30002


### PR DESCRIPTION
I've just created the `humble-devel` branch as it doesn't feel right to merge changes onto `foxy-devel` anymore.

This PR updates the README and CI in order to point to the correct supported ROS distributions. @gavanderhoorn I think it would make sense to make the `humble-devel` branch the default branch for this repo once this PR is merged.

I didn't touch the package maintainers, would it make sense to update them, as well? But we can also take that to another PR...