### PR TITLE
Add action for enabling freedrive mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
+set(action_files
+  action/EnableFreedriveMode.action
+)
+
 set(msg_files
   msg/Analog.msg
   msg/Digital.msg
@@ -30,6 +34,7 @@ if(BUILD_TESTING)
 endif()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  ${action_files}
   ${msg_files}
   ${srv_files}
   DEPENDENCIES builtin_interfaces geometry_msgs

--- a/action/EnableFreedriveMode.action
+++ b/action/EnableFreedriveMode.action
@@ -1,0 +1,5 @@
+# Action to enable freedrive mode
+# once the FreedriveModeController is active
+---
+---
+


### PR DESCRIPTION
The PR adds an action for enabling the freedrive mode once the related controller is active.
Depends on [#1114](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1114), so until that one is not ready for review this PR should be in a blocked state.