### PR TITLE
Increase minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14.4)
 project(ur_msgs)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Increase to CMake 3.14.4, which is the lowest of all supported platforms for ROS Humble (macOS).