### PR TITLE
Add inertia matrix and transition_time support to set_payload service  

### DIFF
--- a/srv/SetPayload.srv
+++ b/srv/SetPayload.srv
@@ -1,4 +1,4 @@
 geometry_msgs/Inertia payload
-float64 transition_time
+builtin_interfaces/Duration transition_time
 ---
 bool success

--- a/srv/SetPayload.srv
+++ b/srv/SetPayload.srv
@@ -1,4 +1,4 @@
-float32 mass
-geometry_msgs/Vector3 center_of_gravity
+geometry_msgs/Inertia payload
+float64 transition_time
 ---
 bool success


### PR DESCRIPTION
## Summary  
  
Extends the `set_payload` service to support setting the full payload inertia matrix  
and a transition time, in addition to the existing mass and center of gravity fields.  
  
Previously, `SetPayload.srv` only accepted `mass` (float32) and `cog` (Vector3).  
This PR replaces those fields with `geometry_msgs/Inertia` (which includes mass, CoG,  
and the full 6-component inertia tensor) and adds a `transition_time` field, enabling  
use of the robot's `set_target_payload(m, cog, inertia, transition_time)` URScript  
function.  

## Related issues  
  
https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1711

**Related PR (ur_ros2_driver):** https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1808