### PR TITLE
Add inertia matrix and transition_time support to set_payload service backwards-compatible

### DIFF
--- a/srv/SetPayload.srv
+++ b/srv/SetPayload.srv
@@ -1,4 +1,11 @@
-geometry_msgs/Inertia payload
-float64 transition_time
+float32 mass
+geometry_msgs/Vector3 center_of_gravity
+float64 ixx  
+float64 iyy  
+float64 izz  
+float64 ixy  
+float64 ixz  
+float64 iyz  
+float64 transition_time  
 ---
 bool success

--- a/srv/SetPayload.srv
+++ b/srv/SetPayload.srv
@@ -1,4 +1,4 @@
-float32 mass
-geometry_msgs/Vector3 center_of_gravity
+geometry_msgs/Inertia payload
+float64 transition_time
 ---
 bool success

--- a/srv/SetPayload.srv
+++ b/srv/SetPayload.srv
@@ -6,6 +6,6 @@ float64 izz
 float64 ixy  
 float64 ixz  
 float64 iyz  
-float64 transition_time  
+builtin_interfaces/Duration transition_time  
 ---
 bool success


### PR DESCRIPTION
## Summary  
  
Extends the `SetPayload` service to support setting the full payload inertia matrix and a transition time, while maintaining backwards compatibility with the existing fields. 

Instead of replacing the original fields, this PR appends the 6-component inertia tensor and `transition_time` directly to the root of the request. This avoids breaking existing callers while still enabling the driver to use the robot's `set_target_payload(m, cog, inertia, transition_time)` URScript function.

The updated `SetPayload.srv` structure is now:

```protobuf
float32 mass  
geometry_msgs/Vector3 center_of_gravity  
float64 ixx  
float64 iyy  
float64 izz  
float64 ixy  
float64 ixz  
float64 iyz  
float64 transition_time  
---  
bool success