### PR TITLE
Action definition for executing scripts via primary client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(srv_files
 set(action_files
   action/ToolContact.action
   action/FollowJointTrajectoryUntil.action
+  action/SendScript.action
 )
 
 if(BUILD_TESTING)

--- a/action/SendScript.action
+++ b/action/SendScript.action
@@ -1,0 +1,23 @@
+# Valid script code, that should be sent to the robot. This can either be a one-liner, or a longer function definition.
+string script_code
+
+# Name for the script which will be used in various log messages. This will be ignored, if a name is already defined in the script code itself.
+string script_name ""
+
+# The maximum amount of time that is allowed to pass, before the script must be confirmed to have started
+builtin_interfaces/Duration start_timeout
+
+# Whether the script execution should report as failed, if the robot generates a warning during execution
+bool fail_on_warnings true
+
+# Whether the underlying interface connection should be restarted, if it is read-only. This will stop and start the primary client connection.
+bool retry_on_readonly_interface true
+
+---
+# Whether the script was successfully exeuted.
+bool success
+
+# Message containing the cause of failure, if any.
+string message
+
+---

--- a/action/SendScript.action
+++ b/action/SendScript.action
@@ -1,5 +1,5 @@
 # Valid script code, that should be sent to the robot. This can either be a one-liner, or a longer function definition.
-string script_code
+string program
 
 # Name for the script which will be used in various log messages. This will be ignored, if a name is already defined in the script code itself.
 string script_name ""


### PR DESCRIPTION
Enables the ROS driver to use the primary client script execution with feedback functionality added to URCL in [484](https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/484), [520](https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/520) and [522](https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/522).

This definition will be used in the urscript_interface of the ROS driver